### PR TITLE
Draft: Remove trailing slash from git clone destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This options is provided for people who want to run the commands themselves.
     sudo apt update
     sudo apt install -y cmake git python3-pip python3-venv
     [ -d ${HOME}/esp ] || mkdir ${HOME}/esp
-    git clone -b v5.1.1 --recursive https://github.com/espressif/esp-idf.git ${HOME}/esp/esp-idf/
+    git clone -b v5.1.1 --recursive https://github.com/espressif/esp-idf.git ${HOME}/esp/esp-idf
     cd "${HOME}"/esp/esp-idf
     ./install.sh esp32
     . ./export.sh
@@ -134,7 +134,7 @@ This options is provided for people who want to run the commands themselves.
   
 3. Download the Jade source code. Copy-and-paste the following lines into Terminal:
     ```bash
-    git clone --recursive https://github.com/blockstream/jade "${HOME}"/jade/
+    git clone --recursive https://github.com/blockstream/jade "${HOME}"/jade
     cd "${HOME}"/jade/
     git checkout $(git tag | grep -v miner | sort -V | tail -1)
     ```

--- a/device_specific/flash_the_m5stack_core_basic
+++ b/device_specific/flash_the_m5stack_core_basic
@@ -20,7 +20,7 @@ apt-get -qq install -y -o=Dpkg::Use-Pty=0 cmake git python3-pip python3-venv &> 
 
 if [ ! -f "${esp_idf_git_dir}"/export.sh ]; then
     [ -d "${esp_dir}" ] || mkdir "${esp_dir}"
-    git clone --quiet https://github.com/espressif/esp-idf.git "${esp_idf_git_dir}"/
+    git clone --quiet https://github.com/espressif/esp-idf.git "${esp_idf_git_dir}"
     cd "${esp_idf_git_dir}"/
     git checkout --quiet "${esp_idf_git_tag}"
     git submodule update --quiet --init --recursive

--- a/device_specific/flash_the_m5stack_fire
+++ b/device_specific/flash_the_m5stack_fire
@@ -20,7 +20,7 @@ apt-get -qq install -y -o=Dpkg::Use-Pty=0 cmake git python3-pip python3-venv &> 
 
 if [ ! -f "${esp_idf_git_dir}"/export.sh ]; then
     [ -d "${esp_dir}" ] || mkdir "${esp_dir}"
-    git clone --quiet https://github.com/espressif/esp-idf.git "${esp_idf_git_dir}"/
+    git clone --quiet https://github.com/espressif/esp-idf.git "${esp_idf_git_dir}"
     cd "${esp_idf_git_dir}"/
     git checkout --quiet "${esp_idf_git_tag}"
     git submodule update --quiet --init --recursive

--- a/device_specific/flash_the_m5stack_m5stickc_plus
+++ b/device_specific/flash_the_m5stack_m5stickc_plus
@@ -20,7 +20,7 @@ apt-get -qq install -y -o=Dpkg::Use-Pty=0 cmake git python3-pip python3-venv &> 
 
 if [ ! -f "${esp_idf_git_dir}"/export.sh ]; then
     [ -d "${esp_dir}" ] || mkdir "${esp_dir}"
-    git clone --quiet https://github.com/espressif/esp-idf.git "${esp_idf_git_dir}"/
+    git clone --quiet https://github.com/espressif/esp-idf.git "${esp_idf_git_dir}"
     cd "${esp_idf_git_dir}"/
     git checkout --quiet "${esp_idf_git_tag}"
     git submodule update --quiet --init --recursive

--- a/device_specific/flash_the_ttgo_tdisplay
+++ b/device_specific/flash_the_ttgo_tdisplay
@@ -20,7 +20,7 @@ apt-get -qq install -y -o=Dpkg::Use-Pty=0 cmake git python3-pip python3-venv &> 
 
 if [ ! -f "${esp_idf_git_dir}"/export.sh ]; then
     [ -d "${esp_dir}" ] || mkdir "${esp_dir}"
-    git clone --quiet https://github.com/espressif/esp-idf.git "${esp_idf_git_dir}"/
+    git clone --quiet https://github.com/espressif/esp-idf.git "${esp_idf_git_dir}"
     cd "${esp_idf_git_dir}"/
     git checkout --quiet "${esp_idf_git_tag}"
     git submodule update --quiet --init --recursive

--- a/flash_your_device
+++ b/flash_your_device
@@ -92,7 +92,7 @@ esac
 echo -n "Checking for the Espressif IoT Development Framework... "
 if [ ! -f "${esp_idf_git_dir}"/export.sh ]; then
     echo -ne "\n  Downloading the framework... "
-    git clone --quiet https://github.com/espressif/esp-idf.git "${esp_idf_git_dir}"/
+    git clone --quiet https://github.com/espressif/esp-idf.git "${esp_idf_git_dir}"
     cd "${esp_idf_git_dir}"/
     git checkout --quiet "${esp_idf_git_tag}"
     git submodule update --quiet --init --recursive


### PR DESCRIPTION
When performing `git clone`, don't refer to the destination directory with a trailing slash.
Use `/path/to/destination`, not `/path/to/destination/`.