### PR TITLE
fix: typo in CONFIG_LOG_DEFAULT_LEVEL_NONE to properly disable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ TODO: Add instructions for installing macOS dependendies.
 6. Modify the configuration file you just loaded to disable logging in debug mode (a.k.a. "research and development" mode).
     ```bash
     sed -i.bak '/CONFIG_DEBUG_MODE/d' ./sdkconfig.defaults
-    sed -i.bak '1s/^/CONFIG_LOG_DEFUALT_LEVEL_NONE=y\n/' sdkconfig.defaults
+    sed -i.bak '1s/^/CONFIG_LOG_DEFAULT_LEVEL_NONE=y\n/' sdkconfig.defaults
     rm sdkconfig.defaults.bak
     ```
 

--- a/device_specific/flash_the_m5stack_core_basic
+++ b/device_specific/flash_the_m5stack_core_basic
@@ -78,7 +78,7 @@ jade_version="$(git describe --tags)"
 
 cp configs/sdkconfig_display_m5blackgray.defaults sdkconfig.defaults
 sed -i.bak '/CONFIG_DEBUG_MODE/d' ./sdkconfig.defaults
-sed -i.bak '1s/^/CONFIG_LOG_DEFUALT_LEVEL_NONE=y\n/' sdkconfig.defaults
+sed -i.bak '1s/^/CONFIG_LOG_DEFAULT_LEVEL_NONE=y\n/' sdkconfig.defaults
 rm sdkconfig.defaults.bak
 
 idf.py build

--- a/device_specific/flash_the_m5stack_fire
+++ b/device_specific/flash_the_m5stack_fire
@@ -78,7 +78,7 @@ jade_version="$(git describe --tags)"
 
 cp configs/sdkconfig_display_m5fire.defaults sdkconfig.defaults
 sed -i.bak '/CONFIG_DEBUG_MODE/d' ./sdkconfig.defaults
-sed -i.bak '1s/^/CONFIG_LOG_DEFUALT_LEVEL_NONE=y\n/' sdkconfig.defaults
+sed -i.bak '1s/^/CONFIG_LOG_DEFAULT_LEVEL_NONE=y\n/' sdkconfig.defaults
 rm sdkconfig.defaults.bak
 
 idf.py build

--- a/device_specific/flash_the_m5stack_m5stickc_plus
+++ b/device_specific/flash_the_m5stack_m5stickc_plus
@@ -78,7 +78,7 @@ jade_version="$(git describe --tags)"
 
 cp configs/sdkconfig_display_m5stickcplus.defaults sdkconfig.defaults
 sed -i.bak '/CONFIG_DEBUG_MODE/d' ./sdkconfig.defaults
-sed -i.bak '1s/^/CONFIG_LOG_DEFUALT_LEVEL_NONE=y\n/' sdkconfig.defaults
+sed -i.bak '1s/^/CONFIG_LOG_DEFAULT_LEVEL_NONE=y\n/' sdkconfig.defaults
 rm sdkconfig.defaults.bak
 
 idf.py build

--- a/device_specific/flash_the_ttgo_tdisplay
+++ b/device_specific/flash_the_ttgo_tdisplay
@@ -78,7 +78,7 @@ jade_version="$(git describe --tags)"
 
 cp configs/sdkconfig_display_ttgo_tdisplay.defaults sdkconfig.defaults
 sed -i.bak '/CONFIG_DEBUG_MODE/d' ./sdkconfig.defaults
-sed -i.bak '1s/^/CONFIG_LOG_DEFUALT_LEVEL_NONE=y\n/' sdkconfig.defaults
+sed -i.bak '1s/^/CONFIG_LOG_DEFAULT_LEVEL_NONE=y\n/' sdkconfig.defaults
 rm sdkconfig.defaults.bak
 
 idf.py build

--- a/flash_your_device
+++ b/flash_your_device
@@ -169,7 +169,7 @@ fi
 
 [ -f sdkconfig ] && rm sdkconfig
 sed -i.bak '/CONFIG_DEBUG_MODE/d' ./sdkconfig.defaults
-sed -i.bak '1s/^/CONFIG_LOG_DEFUALT_LEVEL_NONE=y\n/' sdkconfig.defaults
+sed -i.bak '1s/^/CONFIG_LOG_DEFAULT_LEVEL_NONE=y\n/' sdkconfig.defaults
 
 echo -n "Building the Jade firmware... "
 idf.py build &> /dev/null


### PR DESCRIPTION
There is a typo in the CONFIG_LOG_DEFAULT_LEVEL_NONE variable preventing from properly disable logging