### PR TITLE
Add DEPRECATED message to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# DEPRECATED
+Please use https://github.com/bitcoin-tools/diyjade instead, per the [issue listed here](https://github.com/epiccurious/jade-diy/issues/78).
+
 # Jade Do-It-Yourself Hardware Guide
 
 This guide is designed for the general user who is not incompetant with computers and is looking to secure **less** than $100,000 (in 2023 prices) worth of bitcoin.


### PR DESCRIPTION
This tripped me up for a bit when getting Jade up and running.

Digging through the issues, I found [this one](https://github.com/epiccurious/jade-diy/issues/78) that points to the latest iteration of this tool. The latest iteration of the tool there worked like a charm.

Proposing the DEPRECATED message to help others like myself get a little bit of their time back.